### PR TITLE
Added NullPointerException on missing Cookie key and value

### DIFF
--- a/src/main/java/com/kttdevelopment/simplehttpserver/SimpleHttpCookie.java
+++ b/src/main/java/com/kttdevelopment/simplehttpserver/SimpleHttpCookie.java
@@ -43,8 +43,14 @@ public class SimpleHttpCookie {
      * @author Ktt Development
      */
     public SimpleHttpCookie(final String name, final String value, final String domain, final String path, final String sameSite, final Date expires, final Integer maxAge, final boolean secure, final boolean httpOnly){
-        this.name = name;
-        this.value = value;
+        if(name == null)
+            throw new NullPointerException("Cookie name can not be null");
+        else
+            this.name = name;
+        if(value == null)
+            throw new NullPointerException("Cookie value can not be null");
+        else
+            this.value = value;
         this.domain = domain;
         this.path = path;
         this.sameSite = sameSite;


### PR DESCRIPTION
### Prerequisites
*If **all** checks are not passed then the pull request will be closed*

- [x] My code follows the style listed in [CONTRIBUTING](https://www.kttdevelopment.com/git/contributing)
- [x] I have checked that no other similar pull requests already exists
- [x] Build compiles
- [x] Build runs without exceptions
- [ ] I have added/modified documentation (if applicable)

### Changes Made
*list changes made and/or relevant issues*

- `SimpleHttpCookie` throws a `NullPointerException` if the key or value is null (not allowed)
