### PR TITLE
Fix #77 - Wrong file when using adapter name on directory files

### DIFF
--- a/src/main/java/com/kttdevelopment/simplehttpserver/handler/DirectoryEntry.java
+++ b/src/main/java/com/kttdevelopment/simplehttpserver/handler/DirectoryEntry.java
@@ -245,9 +245,16 @@ class DirectoryEntry {
             final File parentFile = new File(dabs + relative).getParentFile();
             final String pabs = parentFile.getAbsolutePath();
 
-            // if is in top level directory (both cases) or if is a child of the directory folder (walk case)
-            // null otherwise
-            return pabs.equals(dabs) || (isWalkthrough && pabs.startsWith(dabs)) ? new File(dabs + relative) : null;
+            // if not top level directory or if not child of directory folder, then return null file
+            if(!pabs.equals(dabs) && (!isWalkthrough || !pabs.startsWith(dabs))) return null;
+
+            final String fileName = new File(dabs + relative).getName();
+
+            // for each file in parent directory, run adapter to find file that matches adapted name
+            for(final File file : Objects.requireNonNullElse(parentFile.listFiles(), new File[0]))
+                if(!file.isDirectory() && adapter.getName(file).equals(fileName))
+                    return file;
+            return null;
         }
     }
 

--- a/src/test/java/handlers/SSEHandlerTests.java
+++ b/src/test/java/handlers/SSEHandlerTests.java
@@ -47,7 +47,7 @@ public class SSEHandlerTests {
                 try{
                     while((ln = IN.readLine()) != null)
                             OUT.append(ln).append('\n');
-                }catch(IOException e){
+                }catch(final IOException ignored){
                     Assert.fail("Unable to read input stream from client");
                 }
                 return OUT.toString();

--- a/src/test/java/handlers/ThrottledHandlerTests.java
+++ b/src/test/java/handlers/ThrottledHandlerTests.java
@@ -27,7 +27,7 @@ public class ThrottledHandlerTests {
             new ThrottledHandler(
                 (SimpleHttpHandler) exchange -> {
                     try{ Thread.sleep(TimeUnit.SECONDS.toMillis(3));
-                    }catch(InterruptedException ignored){ }
+                    }catch(final InterruptedException ignored){ }
                     exchange.send(exchange.toString());
                 },
                 new SessionThrottler(sessionHandler){
@@ -51,14 +51,14 @@ public class ThrottledHandlerTests {
             try{
                 HttpClient.newHttpClient().sendAsync(request, HttpResponse.BodyHandlers.ofString())
                     .thenApply(HttpResponse::statusCode).get();
-            }catch(InterruptedException | ExecutionException ignored){ }
+            }catch(final InterruptedException | ExecutionException ignored){ }
         }).start();
 
         Exception exception = null;
         try{
             HttpClient.newHttpClient().sendAsync(request, HttpResponse.BodyHandlers.ofString())
                       .thenApply(HttpResponse::statusCode).get();
-        }catch(InterruptedException | ExecutionException e){ // JDK failure to recognize HttpTimeoutException as valid catch
+        }catch(final InterruptedException | ExecutionException e){ // JDK failure to recognize HttpTimeoutException as valid catch
             exception = e;
         }
         Assert.assertTrue("Second request returned a result for a throttled thread (connection not allowed)",exception instanceof ExecutionException);
@@ -80,7 +80,7 @@ public class ThrottledHandlerTests {
             new ThrottledHandler(
                 (SimpleHttpHandler) exchange -> {
                     try{ Thread.sleep(TimeUnit.SECONDS.toMillis(3));
-                    }catch(InterruptedException ignored){ }
+                    }catch(final InterruptedException ignored){ }
                     exchange.send(exchange.toString());
                 },
                 new ServerSessionThrottler(sessionHandler){
@@ -104,14 +104,14 @@ public class ThrottledHandlerTests {
             try{
                 HttpClient.newHttpClient().sendAsync(request, HttpResponse.BodyHandlers.ofString())
                     .thenApply(HttpResponse::statusCode).get();
-            }catch(InterruptedException | ExecutionException ignored){ }
+            }catch(final InterruptedException | ExecutionException ignored){ }
         }).start();
 
         Exception exception = null;
         try{
             HttpClient.newHttpClient().sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(HttpResponse::statusCode).get();
-        }catch(InterruptedException | ExecutionException e){ // JDK failure to recognize HttpTimeoutException as valid catch
+        }catch(final InterruptedException | ExecutionException e){ // JDK failure to recognize HttpTimeoutException as valid catch
             exception = e;
         }
         Assert.assertTrue("Second request returned a result for a throttled thread (connection not allowed)",exception instanceof ExecutionException);
@@ -131,7 +131,7 @@ public class ThrottledHandlerTests {
             new ThrottledHandler(
                 (SimpleHttpHandler) exchange -> {
                     try{ Thread.sleep(TimeUnit.SECONDS.toMillis(3));
-                    }catch(InterruptedException ignored){ }
+                    }catch(final InterruptedException ignored){ }
                     exchange.send(exchange.toString());
                 },
                 new ExchangeThrottler(){
@@ -155,14 +155,14 @@ public class ThrottledHandlerTests {
             try{
                 HttpClient.newHttpClient().sendAsync(request, HttpResponse.BodyHandlers.ofString())
                     .thenApply(HttpResponse::statusCode).get();
-            }catch(InterruptedException | ExecutionException ignored){ }
+            }catch(final InterruptedException | ExecutionException ignored){ }
         }).start();
 
         Exception exception = null;
         try{
             HttpClient.newHttpClient().sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(HttpResponse::statusCode).get();
-        }catch(InterruptedException | ExecutionException e){ // JDK failure to recognize HttpTimeoutException as valid catch
+        }catch(final InterruptedException | ExecutionException e){ // JDK failure to recognize HttpTimeoutException as valid catch
             exception = e;
         }
         Assert.assertTrue("Second request returned a result for a throttled thread (connection not allowed)",exception instanceof ExecutionException);
@@ -182,7 +182,7 @@ public class ThrottledHandlerTests {
             new ThrottledHandler(
                 (SimpleHttpHandler) exchange -> {
                     try{ Thread.sleep(TimeUnit.SECONDS.toMillis(3));
-                    }catch(InterruptedException ignored){ }
+                    }catch(final InterruptedException ignored){ }
                     exchange.send(exchange.toString());
                 },
                 new ServerExchangeThrottler(){
@@ -206,14 +206,14 @@ public class ThrottledHandlerTests {
             try{
                 HttpClient.newHttpClient().sendAsync(request, HttpResponse.BodyHandlers.ofString())
                     .thenApply(HttpResponse::statusCode).get();
-            }catch(InterruptedException | ExecutionException ignored){ }
+            }catch(final InterruptedException | ExecutionException ignored){ }
         }).start();
 
         Exception exception = null;
         try{
             HttpClient.newHttpClient().sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(HttpResponse::statusCode).get();
-        }catch(InterruptedException | ExecutionException e){ // JDK failure to recognize HttpTimeoutException as valid catch
+        }catch(final InterruptedException | ExecutionException e){ // JDK failure to recognize HttpTimeoutException as valid catch
             exception = e;
         }
         Assert.assertTrue("Second request returned a result for a throttled thread (connection not allowed)",exception instanceof ExecutionException);

--- a/src/test/java/simplehttpserver/SimpleHttpServerBindTests.java
+++ b/src/test/java/simplehttpserver/SimpleHttpServerBindTests.java
@@ -16,17 +16,17 @@ public class SimpleHttpServerBindTests {
 
         Exception exception = null;
         try{ server.bind(-1);
-        }catch(IllegalArgumentException | IOException e){ exception = e; }
+        }catch(final IllegalArgumentException | IOException e){ exception = e; }
         Assert.assertTrue("Bind server to bad port (-1) should throw an exception", exception instanceof  IllegalArgumentException);
 
         exception = null;
         try{ server.bind(65536);
-        }catch(IllegalArgumentException | IOException e){ exception = e; }
+        }catch(final IllegalArgumentException | IOException e){ exception = e; }
         Assert.assertTrue("Bind server to bad port (65536) should throw an exception", exception instanceof  IllegalArgumentException);
 
         exception = null;
         try{ server.bind(port);
-        }catch(IllegalArgumentException | IOException e){ exception = e; }
+        }catch(final IllegalArgumentException | IOException e){ exception = e; }
         Assert.assertNull("Bind server to valid port (" + port + ") should not throw an exception",exception);
 
         Assert.assertNotNull("Server address should not be null for successful bind",server.getAddress());

--- a/src/test/java/simplehttpserver/SimpleHttpServerContextTests.java
+++ b/src/test/java/simplehttpserver/SimpleHttpServerContextTests.java
@@ -39,20 +39,13 @@ public class SimpleHttpServerContextTests {
 
         Exception exception = null;
         try{ server.removeContext((String) null);
-        }catch(NullPointerException e){ exception = e; }
+        }catch(final NullPointerException e){ exception = e; }
         Assert.assertNotNull("Null string context should throw NPE", exception);
-
-        /* broken
-        exception = null;
-        try{ server.removeContext((HttpContext) null);
-        }catch(NullPointerException e){ exception = e; }
-        Assert.assertNotNull("Null http context should throw NPE", exception);
-        */
 
         String context = "";
         exception = null;
         try{ server.removeContext(context);
-        }catch(IllegalArgumentException e){ exception = e; }
+        }catch(final IllegalArgumentException e){ exception = e; }
         Assert.assertNotNull("Server should throw IllegalArgumentException when removing a context that doesn't exist", exception);
     }
 
@@ -63,12 +56,12 @@ public class SimpleHttpServerContextTests {
         final String context = "";
         server.createContext(context);
         try{ server.removeContext(context);
-        }catch(IllegalArgumentException e){
+        }catch(final IllegalArgumentException ignored){
             Assert.fail("Server should not throw exception when removing existing string context");
         }
 
         try{ server.removeContext(server.createContext(context));
-        }catch(IllegalArgumentException e){
+        }catch(final IllegalArgumentException ignored){
             Assert.fail("Server should not throw exception when removing existing http context");
         }
     }
@@ -79,7 +72,7 @@ public class SimpleHttpServerContextTests {
         String context = "/";
 
         try{ server.removeContext(server.getHttpServer().createContext(context));
-        }catch(IllegalArgumentException ignored){
+        }catch(final IllegalArgumentException ignored){
             Assert.fail("Removing a context added by the native http server should not throw an exception");
         }
 
@@ -87,7 +80,7 @@ public class SimpleHttpServerContextTests {
         server.getHttpServer().removeContext(context);
         try{
             server.createContext(context);
-        }catch(IllegalArgumentException ignored){
+        }catch(final IllegalArgumentException ignored){
             Assert.fail("Server should be able to create a new context if removed by native http server");
         }
     }
@@ -120,7 +113,7 @@ public class SimpleHttpServerContextTests {
         Exception exception = null;
         try{
             server.createContext(context,handler);
-        }catch(IllegalArgumentException e){ exception = e; }
+        }catch(final IllegalArgumentException e){ exception = e; }
         Assert.assertNotNull("Server should throw IllegalArgumentException when adding RootHandler to non-root context",exception);
 
         final String[] testRoots = {"/","\\",""};


### PR DESCRIPTION
### Prerequisites
*If **all** checks are not passed then the pull request will be closed*

- [x] My code follows the style listed in [CONTRIBUTING](https://www.kttdevelopment.com/github/contributing)
- [x] I have checked that no other similar pull requests already exists
- [x] Build compiles
- [x] Build runs without exceptions
- [x] I have added/modified documentation (if applicable)

### Changes Made
*list changes made and/or relevant issues*

- Fixed issue where retrieving a file from a directory when using a file name adapter would not return the correct file (it would return a file using the adapted name instead of the file with the unadapted name).
- Added test for this bug.
- Cleaned up other tests exception catches (made final/ignored).
