### PR TITLE
Fix throttler tests

### DIFF
--- a/src/test/java/com/kttdevelopment/simplehttpserver/handlers/throttler/ExchangeThrottlerTest.java
+++ b/src/test/java/com/kttdevelopment/simplehttpserver/handlers/throttler/ExchangeThrottlerTest.java
@@ -12,8 +12,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.*;
 import java.time.Duration;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 public final class ExchangeThrottlerTest {
 
@@ -22,6 +21,7 @@ public final class ExchangeThrottlerTest {
         final int port = 8080;
 
         final SimpleHttpServer server = SimpleHttpServer.create(port);
+        server.setExecutor(Executors.newCachedThreadPool());
 
         final String context = "";
         server.createContext(

--- a/src/test/java/com/kttdevelopment/simplehttpserver/handlers/throttler/ServerExchangeThrottlerTest.java
+++ b/src/test/java/com/kttdevelopment/simplehttpserver/handlers/throttler/ServerExchangeThrottlerTest.java
@@ -19,6 +19,7 @@ public final class ServerExchangeThrottlerTest {
         final int port = 8080;
 
         final SimpleHttpServer server = SimpleHttpServer.create(port);
+        server.setExecutor(Executors.newCachedThreadPool());
 
         final String context = "";
         server.createContext(

--- a/src/test/java/com/kttdevelopment/simplehttpserver/handlers/throttler/ServerSessionThrottlerTest.java
+++ b/src/test/java/com/kttdevelopment/simplehttpserver/handlers/throttler/ServerSessionThrottlerTest.java
@@ -11,8 +11,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.*;
 import java.time.Duration;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 public final class ServerSessionThrottlerTest {
 
@@ -21,6 +20,7 @@ public final class ServerSessionThrottlerTest {
         final int port = 8080;
 
         final SimpleHttpServer server = SimpleHttpServer.create(port);
+        server.setExecutor(Executors.newCachedThreadPool());
         final HttpSessionHandler sessionHandler = new HttpSessionHandler();
         server.setHttpSessionHandler(sessionHandler);
 

--- a/src/test/java/com/kttdevelopment/simplehttpserver/handlers/throttler/SessionThrottlerTest.java
+++ b/src/test/java/com/kttdevelopment/simplehttpserver/handlers/throttler/SessionThrottlerTest.java
@@ -11,8 +11,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.*;
 import java.time.Duration;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 public final class SessionThrottlerTest {
 
@@ -21,6 +20,7 @@ public final class SessionThrottlerTest {
         final int port = 8080;
 
         final SimpleHttpServer server = SimpleHttpServer.create(port);
+        server.setExecutor(Executors.newCachedThreadPool());
         final HttpSessionHandler sessionHandler = new HttpSessionHandler();
         server.setHttpSessionHandler(sessionHandler);
 


### PR DESCRIPTION
Changed throttler tests to run on multithreaded servers. The existing tests were likely to always pass on single threaded servers.
