### PR TITLE
Fixed #115, GET wildcards +& not parsed correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.kttdevelopment</groupId>
     <artifactId>simplehttpserver</artifactId>
-    <version>4.1.0</version>
+    <version>4.2.0</version>
 
     <name>simplehttpserver</name>
     <description>📕 SimpleHttpServer :: Simplified implementation of the sun http server :: Simplified handlers to execute complex operations</description>

--- a/src/main/java/com/kttdevelopment/simplehttpserver/SimpleHttpExchangeImpl.java
+++ b/src/main/java/com/kttdevelopment/simplehttpserver/SimpleHttpExchangeImpl.java
@@ -18,7 +18,7 @@ import java.util.zip.GZIPOutputStream;
  *
  * @see SimpleHttpExchange
  * @since 02.00.00
- * @version 4.0.0
+ * @version 4.2.0
  * @author Ktt Development
  */
 @SuppressWarnings("SpellCheckingInspection")
@@ -119,7 +119,7 @@ final class SimpleHttpExchangeImpl extends SimpleHttpExchange {
                 requestMethod = RequestMethod.UNSUPPORTED; break;
         }
     //
-        hasGet = (rawGet = URI.getQuery()) != null;
+        hasGet = (rawGet = URI.getRawQuery()) != null;
         getMap = hasGet ? Collections.unmodifiableMap(parseWwwFormEnc.apply(rawGet)) : new HashMap<>();
 
     //

--- a/src/test/java/com/kttdevelopment/simplehttpserver/simplehttpexchange/io/SimpleHttpExchangeGetTest.java
+++ b/src/test/java/com/kttdevelopment/simplehttpserver/simplehttpexchange/io/SimpleHttpExchangeGetTest.java
@@ -33,7 +33,8 @@ public final class SimpleHttpExchangeGetTest {
         server.start();
 
         final String queryKey = "test", queryValue = "value";
-        final String url = "http://localhost:" + port + context + '?' + queryKey + '=' + queryValue;
+        final String altKey   = "alt", altValueRaw = "a+?&}", altValueEnc = "a%2B%3F%26%7D";
+        final String url      = "http://localhost:" + port + context + '?' + queryKey + '=' + queryValue + '&' + altKey + '=' + altValueEnc;
 
         HttpRequest request = HttpRequest.newBuilder()
             .uri(URI.create(url))
@@ -51,6 +52,7 @@ public final class SimpleHttpExchangeGetTest {
         Assertions.assertEquals(RequestMethod.GET, exchange.getRequestMethod(), "Client request method did not match exchange request method (GET)");
         Assertions.assertTrue(exchange.hasGet(), "Exchange was missing client GET map");
         Assertions.assertEquals(queryValue, exchange.getGetMap().get(queryKey), "Exchange GET did not match client GET");
+        Assertions.assertEquals(altValueRaw, exchange.getGetMap().get(altKey), "Exchange GET did not match client GET");
     }
 
 }


### PR DESCRIPTION
Fixed issue where wildcards `+` and `&` were decoded incorrectly, causing the `GET` map to be incorrect.