### PR TITLE
Fixed issue where file handler would sometimes return null for existing files; Optimized LIVELOAD file handler.

### DIFF
--- a/src/main/java/com/kttdevelopment/simplehttpserver/handler/DirectoryEntry.java
+++ b/src/main/java/com/kttdevelopment/simplehttpserver/handler/DirectoryEntry.java
@@ -14,7 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @see FileHandler
  * @see FileEntry
  * @since 02.00.00
- * @version 4.0.0
+ * @version 4.2.0
  * @author Ktt Development
  */
 @SuppressWarnings("SpellCheckingInspection")

--- a/src/main/java/com/kttdevelopment/simplehttpserver/handler/DirectoryEntry.java
+++ b/src/main/java/com/kttdevelopment/simplehttpserver/handler/DirectoryEntry.java
@@ -170,7 +170,7 @@ class DirectoryEntry {
         final FileEntry entry = files.get(context);
         if(entry == null){ // add new entry if not already added and file exists
             final File file = getFile(path);
-            return file != null && !file.exists()
+            return file != null && file.exists()
                 ? files.put(context, new FileEntry(file, adapter, loadingOption))
                 : null;
         }else if(!entry.getFile().exists()){ // remove entry if file no longer exists

--- a/src/main/java/com/kttdevelopment/simplehttpserver/handler/DirectoryEntry.java
+++ b/src/main/java/com/kttdevelopment/simplehttpserver/handler/DirectoryEntry.java
@@ -171,7 +171,9 @@ class DirectoryEntry {
         if(entry == null){ // add new entry if not already added and file exists
             final File file = getFile(path);
             return file != null && file.exists()
-                ? files.put(context, new FileEntry(file, adapter, loadingOption))
+                ? loadingOption != ByteLoadingOption.LIVELOAD // only add to files if not liveload
+                    ? files.put(context, new FileEntry(file, adapter, loadingOption))
+                    : new FileEntry(file, adapter, loadingOption)
                 : null;
         }else if(!entry.getFile().exists()){ // remove entry if file no longer exists
             files.remove(context);


### PR DESCRIPTION
### Prerequisites
*If **all** checks are not passed then the pull request will be closed.*

- [x] My code follows the style listed in [CONTRIBUTING](https://github.com/Ktt-Development/.github/blob/main/CONTRIBUTING.md).
- [x] I have checked that no other similar pull requests already exists.
- [x] Build compiles.
- [x] Build runs without exceptions.
- [x] I have added/modified documentation (if applicable).
- [x] I have added/modified test cases.

### Changes Made
*List changes made and/or relevant issues. Please keep changed in reverse chronological order (newest at top).*

https://github.com/Ktt-Development/simplehttpserver/blob/ab1a8fd976d59e12ee300d6a72167113677f6ab7/src/main/java/com/kttdevelopment/simplehttpserver/handler/DirectoryEntry.java#L171-L175

- Fixed #117, The solution was already in the above comment, the bug was just a typo.
- Optimized directory entry (fixed memory issue caused by saving files in liveload).